### PR TITLE
Update maven-javadoc-plugin from 2.9.1 to 3.3.2 to partially fix mvn …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version>
+					<version>3.3.2</version>
 					<executions>
 						<execution>
 							<id>attach-javadocs</id>


### PR DESCRIPTION
…clean install.

See https://github.com/SmartDataAnalytics/Sparqlify/issues/94.
It still does not build all components but at least the first few now whereas before none of them did.